### PR TITLE
Add standard catalog test

### DIFF
--- a/singer_tap_tester/standard_tests/__init__.py
+++ b/singer_tap_tester/standard_tests/__init__.py
@@ -1,2 +1,2 @@
 from .canary import test_sync_canary
-#from .catalog import test_catalog_standards # TODO
+from .catalog import test_catalog_standards

--- a/singer_tap_tester/standard_tests/catalog.py
+++ b/singer_tap_tester/standard_tests/catalog.py
@@ -1,0 +1,127 @@
+import re
+from singer_tap_tester import cli, user
+
+def test_catalog_standards(scenario):
+    """
+    The purpose of this test is to run the tap's discovery mode and 
+    verify a valid catalog is produced
+    """
+    catalog = cli.run_discovery(scenario.tap_name, scenario.get_config())
+
+    # Verify only expected streams were discovered
+    expected_streams = scenario.expected_streams()
+    discovered_streams = {entry['stream'] for entry in catalog['streams']}
+    scenario.assertSetEqual(expected_streams, discovered_streams)
+
+    # Verify tap_stream_id follows the naming convention that
+    # streams should only have lowercase alphas and underscores
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+
+            scenario.assertTrue(re.fullmatch(r"[a-z_0-9]+",  catalog_entry['tap_stream_id']),
+                            msg="This stream doesn't follow standard naming.")
+            
+    # verify there is only 1 top level breadcrumb in metadata
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+
+            scenario.assertEqual(1, len(stream_properties))
+
+    # verify expected primary key(s) are specified in metadata
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            expected_primary_keys = scenario.expected_primary_keys()[stream]
+
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            actual_primary_keys = set(
+                stream_properties[0].get(
+                    "metadata", {scenario.PRIMARY_KEYS: []}).get(scenario.PRIMARY_KEYS, [])
+            )
+
+            scenario.assertSetEqual(expected_primary_keys, actual_primary_keys)
+
+    # verify the forced replication method matches our expectations
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            expected_replication_method = scenario.expected_replication_method()[stream]
+
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            actual_replication_method = stream_properties[0].get(
+                "metadata", {scenario.REPLICATION_METHOD: None}).get(scenario.REPLICATION_METHOD)
+
+            scenario.assertEqual(expected_replication_method, actual_replication_method)
+
+    # verify expected replication key(s) are specified in metadata
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            expected_replication_keys = scenario.expected_replication_keys()[stream]
+
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            actual_replication_keys = set(
+                stream_properties[0].get(
+                    "metadata", {scenario.REPLICATION_KEYS: []}).get(scenario.REPLICATION_KEYS, [])
+            )
+            scenario.assertSetEqual(expected_primary_keys, actual_primary_keys)
+
+    # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL TABLE
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            expected_replication_keys = scenario.expected_replication_keys()[stream]
+
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            actual_replication_method = stream_properties[0].get(
+                "metadata", {scenario.REPLICATION_METHOD: None}).get(scenario.REPLICATION_METHOD)
+            actual_replication_keys = set(
+                stream_properties[0].get(
+                    "metadata", {scenario.REPLICATION_KEYS: []}).get(scenario.REPLICATION_KEYS, [])
+            )
+
+            if actual_replication_keys:
+                scenario.assertEqual(scenario.INCREMENTAL, actual_replication_method)
+            else:
+                scenario.assertEqual(scenario.FULL_TABLE, actual_replication_method)
+
+    # verify that primary keys and replication keys
+    # are given the inclusion of automatic in metadata
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            expected_automatic_fields = scenario.expected_automatic_fields()[stream]
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            actual_automatic_fields = set(
+                item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                if item.get("metadata").get("inclusion") == "automatic"
+            )
+
+            scenario.assertSetEqual(expected_automatic_fields, actual_automatic_fields)
+
+    # verify that all other fields have inclusion of available
+    # This assumes there are no unsupported fields for SaaS sources
+    for stream in expected_streams:
+        with scenario.subTest(stream=stream):
+            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
+            metadata = catalog_entry["metadata"]
+            actual_automatic_fields = set(
+                item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                if item.get("metadata").get("inclusion") == "automatic"
+            )
+
+            scenario.assertTrue(
+                all({item.get("metadata").get("inclusion") == "available"
+                     for item in metadata
+                     if item.get("breadcrumb", []) != []
+                     and item.get("breadcrumb", ["properties", None])[1]
+                     not in actual_automatic_fields}),
+                msg="Not all non key properties are set to available in metadata")

--- a/singer_tap_tester/standard_tests/catalog.py
+++ b/singer_tap_tester/standard_tests/catalog.py
@@ -3,42 +3,54 @@ from singer_tap_tester import cli, user
 
 def test_catalog_standards(scenario):
     """
-    The purpose of this test is to run the tap's discovery mode and 
+    The purpose of this test is to run the tap's discovery mode and
     verify a valid catalog is produced
     """
     catalog = cli.run_discovery(scenario.tap_name, scenario.get_config())
 
-    # Verify only expected streams were discovered
+    def get_catalog_entry(stream):
+        catalog_entry = [entry for entry in catalog['streams']
+                         if entry["stream"] == stream][0]
+        return catalog_entry
+
+    def get_stream_level_properties(stream):
+        catalog_entry = get_catalog_entry(stream)
+        metadata = catalog_entry["metadata"]
+        stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+
+        return stream_properties
+
+
+    # verify only expected streams were discovered
     expected_streams = scenario.expected_streams()
+
     discovered_streams = {entry['stream'] for entry in catalog['streams']}
+
     scenario.assertSetEqual(expected_streams, discovered_streams)
 
-    # Verify tap_stream_id follows the naming convention that
+
+    # verify tap_stream_id follows the naming convention that
     # streams should only have lowercase alphas and underscores
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-
+            catalog_entry = get_catalog_entry(stream)
             scenario.assertTrue(re.fullmatch(r"[a-z_0-9]+",  catalog_entry['tap_stream_id']),
                             msg="This stream doesn't follow standard naming.")
-            
+
+
     # verify there is only 1 top level breadcrumb in metadata
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
-            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
-
+            stream_properties = get_stream_level_properties(stream)
             scenario.assertEqual(1, len(stream_properties))
+
 
     # verify expected primary key(s) are specified in metadata
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
             expected_primary_keys = scenario.expected_primary_keys()[stream]
 
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
-            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            stream_properties = get_stream_level_properties(stream)
             actual_primary_keys = set(
                 stream_properties[0].get(
                     "metadata", {scenario.PRIMARY_KEYS: []}).get(scenario.PRIMARY_KEYS, [])
@@ -46,60 +58,47 @@ def test_catalog_standards(scenario):
 
             scenario.assertSetEqual(expected_primary_keys, actual_primary_keys)
 
-    # verify the forced replication method matches our expectations
+
+    # test replication methods in metadata
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
-            expected_replication_method = scenario.expected_replication_method()[stream]
 
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
-            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            expected_replication_method = scenario.expected_replication_method()[stream]
+            expected_replication_keys = scenario.expected_replication_keys()[stream]
+
+            stream_properties = get_stream_level_properties(stream)
             actual_replication_method = stream_properties[0].get(
                 "metadata", {scenario.REPLICATION_METHOD: None}).get(scenario.REPLICATION_METHOD)
+            actual_replication_keys = set(
+                stream_properties[0].get(
+                    "metadata", {scenario.REPLICATION_KEYS: []}).get(scenario.REPLICATION_KEYS, [])
+            )
 
+            # verify the forced replication method matches our expectations
             scenario.assertEqual(expected_replication_method, actual_replication_method)
 
-    # verify expected replication key(s) are specified in metadata
-    for stream in expected_streams:
-        with scenario.subTest(stream=stream):
-            expected_replication_keys = scenario.expected_replication_keys()[stream]
+            # verify expected replication key(s) are specified in metadata
+            scenario.assertSetEqual(expected_replication_keys, actual_replication_keys)
 
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
-            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
-            actual_replication_keys = set(
-                stream_properties[0].get(
-                    "metadata", {scenario.REPLICATION_KEYS: []}).get(scenario.REPLICATION_KEYS, [])
-            )
-            scenario.assertSetEqual(expected_primary_keys, actual_primary_keys)
-
-    # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL TABLE
-    for stream in expected_streams:
-        with scenario.subTest(stream=stream):
-            expected_replication_keys = scenario.expected_replication_keys()[stream]
-
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
-            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
-            actual_replication_method = stream_properties[0].get(
-                "metadata", {scenario.REPLICATION_METHOD: None}).get(scenario.REPLICATION_METHOD)
-            actual_replication_keys = set(
-                stream_properties[0].get(
-                    "metadata", {scenario.REPLICATION_KEYS: []}).get(scenario.REPLICATION_KEYS, [])
-            )
-
+            # verify that if there is a replication key we are doing INCREMENTAL
             if actual_replication_keys:
-                scenario.assertEqual(scenario.INCREMENTAL, actual_replication_method)
-            else:
-                scenario.assertEqual(scenario.FULL_TABLE, actual_replication_method)
+                scenario.assertEqual(
+                    scenario.INCREMENTAL, actual_replication_method,
+                    msg=f"Invalid replication.  Method: {actual_replication_method}  Replication Keys: {actual_replication_keys}."
+                )
+            else:  # verify if there is no replication key we are doing FULL TABLE
+                scenario.assertEqual(
+                    scenario.FULL_TABLE, actual_replication_method,
+                    msg=f"Invalid replication.  Method: {actual_replication_method}  Replication Keys: {actual_replication_keys}."
+                )
 
     # verify that primary keys and replication keys
     # are given the inclusion of automatic in metadata
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
             expected_automatic_fields = scenario.expected_automatic_fields()[stream]
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
+
+            metadata = get_catalog_entry(stream)["metadata"]
             actual_automatic_fields = set(
                 item.get("breadcrumb", ["properties", None])[1] for item in metadata
                 if item.get("metadata").get("inclusion") == "automatic"
@@ -111,17 +110,19 @@ def test_catalog_standards(scenario):
     # This assumes there are no unsupported fields for SaaS sources
     for stream in expected_streams:
         with scenario.subTest(stream=stream):
-            catalog_entry = [entry for entry in catalog['streams'] if entry["stream"] == stream][0]
-            metadata = catalog_entry["metadata"]
+            metadata = get_catalog_entry(stream)["metadata"]
+
+            actual_fields = set(
+                item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                if item.get("breadcrumb") != []
+            )
             actual_automatic_fields = set(
                 item.get("breadcrumb", ["properties", None])[1] for item in metadata
                 if item.get("metadata").get("inclusion") == "automatic"
+           )
+            actual_available_fields = set(
+                item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                if item.get("metadata").get("inclusion") == "available"
             )
 
-            scenario.assertTrue(
-                all({item.get("metadata").get("inclusion") == "available"
-                     for item in metadata
-                     if item.get("breadcrumb", []) != []
-                     and item.get("breadcrumb", ["properties", None])[1]
-                     not in actual_automatic_fields}),
-                msg="Not all non key properties are set to available in metadata")
+            scenario.assertSetEqual(actual_fields - actual_automatic_fields, actual_available_fields)

--- a/tests/test_standard_tests.py
+++ b/tests/test_standard_tests.py
@@ -5,6 +5,7 @@ from singer_tap_tester import StandardTests
 
 # Actual Usage Example
 class TestGithubStandard(StandardTests):
+
     tap_name = "tap-github"
 
     def config_environment(self):
@@ -16,6 +17,118 @@ class TestGithubStandard(StandardTests):
             "access_token": os.getenv("TAP_GITHUB_TOKEN"),
             "repository": "singer-io/singer-tap-tester",
             }
+
+    #############################
+    ### Tap Expectations
+    #############################
+
+    def expected_metadata(self):
+        """The expected streams and metadata about the streams"""
+
+        return {
+            "assignees": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "collaborators": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "comments": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "commit_comments": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "commits": {
+                self.PRIMARY_KEYS: {"sha"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "events": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"created_at"}
+            },
+            "issue_labels": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "issue_milestones": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"due_on"}
+            },
+            "issue_events": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"created_at"}
+            },
+            "issues": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "pr_commits": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "project_cards": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "project_columns": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "projects": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "pull_requests": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "releases": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "review_comments": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "reviews": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "stargazers": {
+                self.PRIMARY_KEYS: {"user_id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "team_members": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "team_memberships": {
+                self.PRIMARY_KEYS: {"url"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "teams": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            }
+        }
 
 # Check to ensure that all implementation requirements are checked
 class TestBaseTestRequirements(unittest.TestCase):


### PR DESCRIPTION
# Description of change
Add standard methods to base.py for easily accessing expectations for a given tap.
Add expectations to the `tests/test_standard_tests.py` example using an `expected_metadata` method to generate a dictionary of streams to expected values.
Add discovered catalog assertions to the standard test.

# Manual QA steps
 - Verify each failure output is clear, displaying actual and expected values when possible and overriding the default error message when necessary.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
